### PR TITLE
Fixed bug in demux reducer to allow for [6,12]-base barcodes

### DIFF
--- a/src/it/crs4/seal/demux/DemuxReducer.java
+++ b/src/it/crs4/seal/demux/DemuxReducer.java
@@ -83,9 +83,9 @@ public class DemuxReducer
 				throw new RuntimeException("Missing read 2 in multiplexed input for location " + key.getLocation() + ".  Record: " + fragment);
 
 			indexSeq = fragment.getSequence().toString();
-			if (indexSeq.length() != 7)
-				throw new RuntimeException("Unexpected bar code sequence length " + indexSeq.length() + " (expected 7)");
-			indexSeq = indexSeq.substring(0,6); // trim the last base -- it should be a spacer
+			if ( indexSeq.length() < (SampleSheet.BAR_CODE_MIN_LENGTH + 1) || indexSeq.length() > (SampleSheet.BAR_CODE_MAX_LENGTH + 1) )
+				throw new RuntimeException("Unexpected barcode sequence of length " + indexSeq.length() + " (expected in interval [" + (SampleSheet.BAR_CODE_MIN_LENGTH + 1) + "," + (SampleSheet.BAR_CODE_MAX_LENGTH + 1) + "])");
+			indexSeq = indexSeq.substring(0,indexSeq.length()-1);
 
 			// We've consumed this index read.  Advance to the next one.
 			fragment = seqs_it.next();


### PR DESCRIPTION
The current version of this code fetches a sequence and checks whether its length is 7 (hard-coded).
If the length is 7, then the last base is discarded and the first 6 are kept (hard-coded too).

These lines should be modified to allow for sequences of length in interval [7,13], i.e. BAR_CODE_{MIN,MAX}_LENGTH + 1, defined in https://github.com/crs4/seal/blob/master/src/it/crs4/seal/demux/SampleSheet.java
